### PR TITLE
adjust bootstrap and bindep to better support popos and ubuntu

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,13 +1,18 @@
 build-essential [platform:dpkg]
-gcc [platform:rpm]
+gcc
 libffi-dev [platform:dpkg]
 libffi-devel [platform:rpm]
 python3
+python3-pip
 python3-dev [platform:dpkg]
 python3-devel [platform:rpm]
+python3-libvirt
+libvirt-dev [platform:dpkg]
 libvirt-devel [platform:rpm]
 ruby-devel [platform:rpm]
 redhat-rpm-config [platform:rpm]
-vagrant [platform:rpm]
-rsync [platform:rpm]
+vagrant
+rsync
 libvirt-daemon
+libvirt-clients
+libvirt-daemon-system [plathform:dpkg]

--- a/bootstrap-repo.sh
+++ b/bootstrap-repo.sh
@@ -1,29 +1,22 @@
 #!/bin/bash
+set -x
+which dpkg && sudo apt install -y python3-pip
+which rpm && sudo dnf -y --setopt=install_weak_deps=False install python3-pip
 [[ -e ".venv" ]] || python3 -m venv .venv
 . .venv/bin/activate
-pip install bindep wheel
-set -x
-which dpkg && bindep -b | xargs sudo apt install
+# allow for using local dev copy of bindep if needed
+which bindep || pip install bindep
+pip install wheel
+which dpkg && bindep -b | xargs sudo apt -y install
 # Don't install weak deps, as that will pull in vagrant-libvirt, which we want
 # to install manually later on.
 which rpm && bindep -b | xargs sudo dnf -y --setopt=install_weak_deps=False install
 #pip install ansible=2.9
 pip install ansible\<5 ansible-core\<2.12.0 \
-    molecule molecule-vagrant python-vagrant netaddr molecule-openstack openstacksdk
-# this fails on nixos so install it seperatly until i figure out why.
-pip install libvirt-python
+    molecule!=3.6.1,!=3.6.0 molecule-vagrant python-vagrant netaddr molecule-openstack openstacksdk
 which vagrant && vagrant plugin install vagrant-libvirt
 git submodule update --init --recursive
-# At least on Fedora, the user running this needs to be in the libvirt group to
-# avoid authentication errors when running `molecule create`
-if [[ `cat /etc/redhat-release 2> /dev/null` =~ 'Fedora' ]]
-then
-    if [[ `groups` =~ 'libvirt' ]]
-    then
-        true
-    else
-        echo 'You need to be part of the libvirt group for this to work.'
-        exit
-    fi
-fi
+groups | grep -E "libvirt" > /dev/null || \
+echo -e "You need to be part of the libvirt group for this to work.\nsudo usermod -a -G libvirt $USER"
+
 set +x


### PR DESCRIPTION
This change mainly updates bindep.txt to ensure the deps are
installed properly on pop os 22.04
this also take account of the fact that libvirt is now modular
and starts using libvirt python bindings form the distro.
